### PR TITLE
3.0 patches

### DIFF
--- a/src/main/R/analysis/mode-analysis-spatial.R
+++ b/src/main/R/analysis/mode-analysis-spatial.R
@@ -3,8 +3,8 @@ library(readr)
 library(dplyr)
 
 #define input 
-runDir <- 'Z:/net/ils/schlenther/openHH-calibration/output/output-hv3-25-7-4-3/'
-runID <- "hamburg-v3.0-25pct-base"
+runDir <- 'Z:/net/ils/schlenther/hamburg-v3.0/output/output-hh-base-1pct/'
+runID <- "hamburg-v3.0-1pct-base"
 
 #runDir <- 'Z:/net/ils/schlenther/openHH-calibration/output/output-hv3-10-7-4-4-ff/ITERS/it.0/'
 #runID <- "hamburg-v3.0-10pct-base.0.trips.csv.gz"

--- a/src/main/java/org/matsim/prepare/population/HamburgPrepareOpenPlansFromRawPlansAndCalibratedClosedPlans.java
+++ b/src/main/java/org/matsim/prepare/population/HamburgPrepareOpenPlansFromRawPlansAndCalibratedClosedPlans.java
@@ -67,9 +67,11 @@ public class HamburgPrepareOpenPlansFromRawPlansAndCalibratedClosedPlans {
 		String attributesFile = "../../svn/shared-svn/projects/matsim-hamburg/hamburg-v3/20211118_open_hamburg_delivery_senozon/personAttributes.xml.gz";
 		String plansWithCoordinatesAndIds = "../../svn/shared-svn/projects/matsim-hamburg/hamburg-v3/20211118_open_hamburg_delivery_senozon/population.xml.gz";
 		String plansWithAllTrips = "../../svn/shared-svn/projects/matsim-hamburg/hamburg-v2/hamburg-v2.0/input/hamburg-v2.0-25pct.plans.xml.gz";
-		String targetNetwork = "../../svn/public-svn/matsim/scenarios/countries/de/hamburg/hamburg-v2/hamburg-v2.1/baseCase/input/hamburg-v2.1-network-with-pt.xml.gz";
+
+		//CAUTION: DO NOT USE A NETWORK THAT HAS NON CAR LINKS! WILL LEAD TO PROBLEMS IN THE QSIM IN POLICY CASES AS ACTIVITIES WILL BE ATTACHED TO NON CAR-LINK
+		String targetNetwork = "";
 		String crs = RunBaseCaseHamburgScenario.COORDINATE_SYSTEM;
-		String outputFile = "D:/svn/shared-svn/projects/matsim-hamburg/hamburg-v3/hamburg-v3.0-25pct.plans-not-calibrated.xml.gz";
+		String outputFile = "../../svn/shared-svn/projects/matsim-hamburg/hamburg-v3/hamburg-v3.0-25pct.plans-not-calibrated.xml.gz";
 		String landUseShapeFile = "../../svn/shared-svn/projects/german-wide-freight/landuse/landuse.shp";
 
 		final Random rnd = new Random(1234);

--- a/src/main/java/org/matsim/prepare/population/SetLinkIdsToCarNetwork.java
+++ b/src/main/java/org/matsim/prepare/population/SetLinkIdsToCarNetwork.java
@@ -1,0 +1,85 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.prepare.population;
+
+import com.google.common.base.Preconditions;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.MultimodalNetworkCleaner;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.withinday.replanning.identifiers.filter.TransportModeFilter;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SetLinkIdsToCarNetwork {
+
+	public static void main(String[] args) {
+
+		String inputNetwork = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/hamburg/hamburg-v3/v3.0/input/baseCase/hamburg-v3.0-network-with-pt.xml.gz";
+		String outputNetwork = "D:/svn/public-svn/matsim/scenarios/countries/de/hamburg/hamburg-v3/v3.0/input/baseCase/hamburg-v3.0-car-network.xml.gz";
+		String inputPopulation = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/hamburg/hamburg-v3/v3.0/input/baseCase/hamburg-v3.0-10pct-base.plans.xml.gz";
+		String outputPopulation = "D:/svn/public-svn/matsim/scenarios/countries/de/hamburg/hamburg-v3/v3.0/input/baseCase/hamburg-v3.0-10pct-base.plans-acts-on-car-network.xml.gz";
+
+		Network net = NetworkUtils.readTimeInvariantNetwork(outputNetwork);
+//		filterAndWriteCarNetwork(net, outputNetwork);
+
+		//read population
+		Population population = PopulationUtils.readPopulation(inputPopulation);
+		for (Person person : population.getPersons().values()) {
+			for (Plan plan : person.getPlans()) {
+				List<Activity> acts = TripStructureUtils.getActivities(plan, TripStructureUtils.StageActivityHandling.ExcludeStageActivities);
+				for (Activity act : acts) {
+					if(! net.getLinks().containsKey(act.getLinkId())){ //if linkId is not contained in car network
+						Link link = NetworkUtils.getNearestLink(net, act.getCoord());
+						Preconditions.checkArgument(link.getAllowedModes().contains(TransportMode.car));
+						act.setLinkId(link.getId());
+					}
+				}
+			}
+		}
+
+		PopulationUtils.writePopulation(population, outputPopulation);
+	}
+
+	private static void filterAndWriteCarNetwork(Network net, String outputNetwork) {
+		//filter car network
+		Set<Id<Link>> nonCarLinks = net.getLinks().values().stream()
+				.filter(link -> !link.getAllowedModes().contains(TransportMode.car))
+				.map(link -> link.getId())
+				.collect(Collectors.toSet());
+		nonCarLinks.forEach(nonCarLink -> net.removeLink(nonCarLink));
+		MultimodalNetworkCleaner cleaner = new MultimodalNetworkCleaner(net);
+		cleaner.run(Set.of(TransportMode.car));
+		cleaner.removeNodesWithoutLinks();
+		NetworkUtils.writeNetwork(net, outputNetwork);
+	}
+}

--- a/src/main/java/org/matsim/run/reallabHHPolicyScenarios/RunProKlima2030Scenario.java
+++ b/src/main/java/org/matsim/run/reallabHHPolicyScenarios/RunProKlima2030Scenario.java
@@ -70,7 +70,11 @@ public class RunProKlima2030Scenario {
 	}
 
 	public static Config prepareConfig(String[] args){
-		return RunReallabHH2030Scenario.prepareConfig(args);
+		Config config =  RunReallabHH2030Scenario.prepareConfig(args);
+		String runId = config.controler().getRunId();
+		runId.replace("base", "proKlima2030");
+		config.controler().setRunId(runId);
+		return config;
 	}
 
 	public static Scenario prepareScenario(Config config) throws IOException {


### PR DESCRIPTION
1. a script to attach activities to car links
2. a warning comment in the corresponding scenario generation script, not to use a network with non-car-links
3. automatically adjust runId in proKlima policy scenario
4. some minor input paths adjustments