### PR TITLE
Make adjust freight code more robust

### DIFF
--- a/src/main/java/org/matsim/prepare/freight/bvm/AdjustScenarioForFreight.java
+++ b/src/main/java/org/matsim/prepare/freight/bvm/AdjustScenarioForFreight.java
@@ -56,14 +56,16 @@ public class AdjustScenarioForFreight {
             config.planCalcScore().addModeParams(new PlanCalcScoreConfigGroup.ModeParams(mode).setMonetaryDistanceRate(-0.0004));
         }
 
-        log.info("will delete routes from commercial legs and set coords of commercial activities to coord of their link!! This requires that the input plans were routed at least once, beforehand!");
+        log.info("will delete routes from commercial legs and set coords of commercial activities to coord of their link!! If activities have no link id, nothing happens. The simulation will assign this coord later.");
         scenario.getPopulation().getPersons().values().stream()
-                .filter(person -> PopulationUtils.getSubpopulation(person).equals(COMMERCIAL))
+                .filter(person -> COMMERCIAL.equals(PopulationUtils.getSubpopulation(person)))
                 .flatMap(person -> person.getSelectedPlan().getPlanElements().stream())
                 .forEach(planElement -> {
                     if(planElement instanceof Activity){
                         Id<Link> linkId = ((Activity) planElement).getLinkId();
-                        ((Activity) planElement).setCoord(network.getLinks().get(linkId).getCoord());
+                        if (linkId != null) {
+                            ((Activity) planElement).setCoord(network.getLinks().get(linkId).getCoord());
+                        }
                     } else {
                         ((Leg) planElement).setRoute(null);
                     }


### PR DESCRIPTION
Switch comparison of subpopulation so that null values also pass.
Also, added a null check for link ids on activities, so that also unrouted legs pass this code. 

I did this to make things easier for beginners. The logic for already routed commercial traffic remains the same. 